### PR TITLE
Derive NFData for all generated datatypes

### DIFF
--- a/test/TestDefs.hs
+++ b/test/TestDefs.hs
@@ -6,7 +6,6 @@ module TestDefs where
 
 import Data.List.NonEmpty
 import Data.THGen.XML
-import GHC.Generics (Generic)
 import Test.QuickCheck.Arbitrary.Generic
 import Test.QuickCheck.Instances ()
 
@@ -32,13 +31,9 @@ import Test.QuickCheck.Instances ()
 "Root" =:= record
   ! "Foo"
 
-deriving instance Generic XmlRoot
-
 instance Arbitrary XmlRoot where
   arbitrary = genericArbitrary
   shrink = genericShrink
-
-deriving instance Generic XmlFoo
 
 instance Arbitrary XmlFoo where
   arbitrary = genericArbitrary

--- a/xml-isogen.cabal
+++ b/xml-isogen.cabal
@@ -34,6 +34,7 @@ library
   build-depends:       QuickCheck >= 2.8
                      , base >=4.8 && <5
                      , dom-parser >= 2.0.0
+                     , deepseq
                      , lens >= 4.13
                      , mtl >= 2.2
                      , semigroups >= 0.18
@@ -60,6 +61,7 @@ test-suite spec
   build-depends:      base
                     , QuickCheck
                     , data-default
+                    , deepseq
                     , dom-parser
                     , generic-arbitrary
                     , hspec


### PR DESCRIPTION
Makes benchmarking much easier