### PR TITLE
Add namespaces support

### DIFF
--- a/test/TestDefs.hs
+++ b/test/TestDefs.hs
@@ -29,7 +29,7 @@ import Test.QuickCheck.Instances ()
   ?% "Muux" [t|XmlQuux|]
 
 "Root" =:= record
-  ! "Foo"
+  ! "{http://example.com/ns/my-namespace}Foo"
 
 instance Arbitrary XmlRoot where
   arbitrary = genericArbitrary


### PR DESCRIPTION
Support namespaces in [Clark notation](http://www.jclark.com/xml/xmlns.htm) by converting to [Text.XML.Name](https://www.stackage.org/haddock/lts-10.0/xml-conduit-1.7.0/Text-XML.html#t:Name)

Example:

```
"Header" =:= record
  ! "{http://schemas.xmlsoap.org/ws/2002/12/secext}Security"
```

Will result in:

```
<Header>
  <Security xmlns="http://schemas.xmlsoap.org/ws/2002/12/secext"/>
</Header>
```