### PR TITLE
Add: contents in composite types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   - STACK_YAML=stack.yaml
   - STACK_YAML=ghc-802.yaml
   - STACK_YAML=ghc-822.yaml
-  - STACK_YAML=ghc-841.yaml
+  - STACK_YAML=ghc-844.yaml
 
 cache:
   directories:

--- a/ghc-802.yaml
+++ b/ghc-802.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.0
+resolver: lts-9.21
 
 packages:
 - .

--- a/ghc-822.yaml
+++ b/ghc-822.yaml
@@ -1,1 +1,1 @@
-resolver: lts-10.0
+resolver: lts-11.22

--- a/ghc-843.yaml
+++ b/ghc-843.yaml
@@ -1,3 +1,3 @@
-resolver: nightly-2018-03-20
+resolver: lts-12.11
 extra-deps:
 - dom-parser-3.1.0

--- a/ghc-844.yaml
+++ b/ghc-844.yaml
@@ -1,3 +1,3 @@
-resolver: lts-12.11
+resolver: lts-12.16
 extra-deps:
 - dom-parser-3.1.0

--- a/src/Text/XML/DOM/Parser/Internal/Content.hs
+++ b/src/Text/XML/DOM/Parser/Internal/Content.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Text.XML.DOM.Parser.Internal.Content where
+import Control.Lens
+import Control.Monad.Reader
+import Data.Text as T
+import Text.XML
+import Text.XML.DOM.Parser hiding (getCurrentContent, parseContent)
+
+-- Get current content. If there are more than one content
+-- they are intercalate with space like in xpath `text()`
+--
+getCurrentContent :: (Monad m) => DomParserT Identity m Text
+getCurrentContent
+  = T.intercalate " "
+  . (\e -> [T.strip cs| (NodeContent cs) <- e])
+  . elementNodes
+  . runIdentity
+  . _pdElements
+  <$> ask
+
+parseContent
+  :: (Monad m)
+  => (Text -> Either Text a)
+     -- ^ Content parser, return error msg if value is not parsed
+  -> DomParserT Identity m a
+parseContent parse
+  = getCurrentContent
+  >>= either (throwParserError . PEContentWrongFormat) return . parse

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-6.35
+resolver: lts-10.0
 extra-deps:
 - dom-parser-3.0.0
 - generic-arbitrary-0.1.0

--- a/test/TestDefs.hs
+++ b/test/TestDefs.hs
@@ -4,7 +4,7 @@
 
 module TestDefs where
 
-import Data.List.NonEmpty
+-- import Data.List.NonEmpty
 import Data.THGen.XML
 import Test.QuickCheck.Arbitrary.Generic
 import Test.QuickCheck.Instances ()
@@ -23,6 +23,7 @@ import Test.QuickCheck.Instances ()
   & "US"
 
 "Foo" =:= record
+  ^ "Shmuux" [t|XmlQuux|]
   + "Bar"
   ? "Baz" [t|Text|]
   !% "Quux"

--- a/xml-isogen.cabal
+++ b/xml-isogen.cabal
@@ -1,5 +1,5 @@
 name:                xml-isogen
-version:             0.3.0
+version:             0.3.1
 synopsis:            Generate XML-isomorphic types
 description:
     TemplateHaskell generators for XML-isomorphic data types, including
@@ -32,6 +32,7 @@ library
                      , Data.THGen.XML
                      , Text.XML.ParentAttributes
   other-modules:       Data.THGen.Compat
+                     , Text.XML.DOM.Parser.Internal.Content
   build-depends:       QuickCheck >= 2.8
                      , base >=4.8 && <5
                      , dom-parser >= 2.0.0


### PR DESCRIPTION
close #15 

Added operation (^) to provide isomorphism for xml-content.

There is a replacement for `dom-parser` function `parseContent`. In `dom-parser` it works rather strange: when element have some child nodes content is not recognized. I change that in replacement to use content in this case as well.

