### PR TITLE
Make lens generation optional

### DIFF
--- a/src/Data/THGen/XML.hs
+++ b/src/Data/THGen/XML.hs
@@ -40,7 +40,7 @@ to be either @R@, @G@ or @B@.
 
 Example 2.
 
-> "Message" =:= record Both
+> "Message" =:= record Both Lens
 >   ! "author"
 >   + "recipient"
 >   ? "message" [t|Text|]
@@ -78,8 +78,11 @@ the data type to be generated. The prefix for the record fields is
 inferred automatically by taking all of the uppercase letters in the
 name. You can override it manually like so:
 
-> "Reference" "ref" =:= record Parser
+> "Reference" "ref" =:= record Parser Lens
 >    ...
+
+Second argument to @record@ either enabled lens generation for records fields
+or disables it for use with DuplicateRecordFields and, possibly, generic-lens.
 
 To describe a record field you must supply its name as it appears
 in the XML tag, prefixed by its repetition kind:
@@ -93,7 +96,7 @@ The type of the field is inferred automatically from its name, so
 if the field is called @"author"@ its type will be @Author@. You can
 override the type by specifying it in quasiquotes like so:
 
-> "Message" =:= record Both
+> "Message" =:= record Both NoLens
 >   ! "author" [t|Person|].
 >   ...
 
@@ -109,6 +112,7 @@ module Data.THGen.XML
   , PrefixName(..)
   , ExhaustivenessName(..)
   , GenType(..)
+  , GenerateLens(..)
   , record
   , enum
   , (!)

--- a/src/Data/THGen/XML/Internal.hs
+++ b/src/Data/THGen/XML/Internal.hs
@@ -24,10 +24,11 @@ import           Text.XML.ParentAttributes
 import qualified Text.XML.Writer as XW
 
 
--- | Marks the type of code generation:
--- Parser - generate only instances for xml parsing (@FromDom@)
--- Generator - generate only @ToXML@ instances
--- Both - generate @FromDom@ and @ToXML@ instances
+{- | Marks the type of code generation:
+@Parser@ - generate only instances for xml parsing (@FromDom@)
+@Generator@ - generate only @ToXML@ instances
+@Both@ - generate @FromDom@ and @ToXML@ instances
+-}
 data GenType = Parser | Generator | Both
 
 {- | Marks the style of code generation regarding records fields
@@ -324,7 +325,9 @@ isoXmlGenerateDatatype
     -- generate a newtype instead to do less allocations later
     then THC.newtypeD name (TH.recC name fields) [''Eq, ''Show, ''Generic]
     else THC.dataD name [TH.recC name fields] [''Eq, ''Show, ''Generic]
-  lensDecls <- makeFieldOpticsForDec lensRules termDecl
+  lensDecls <- case generateLens of
+    NoLens       -> pure []
+    LensRenaming -> makeFieldOpticsForDec lensRules termDecl
   nfDataInst <- do
     TH.instanceD
       (return [])

--- a/test/TestDefs.hs
+++ b/test/TestDefs.hs
@@ -22,14 +22,14 @@ import Test.QuickCheck.Instances ()
   & "TO"
   & "US"
 
-"Foo" =:= record Both
+"Foo" =:= record Both NoLens
   ^ "Shmuux" [t|XmlQuux|]
   + "Bar"
   ? "Baz" [t|Text|]
   !% "Quux"
   ?% "Muux" [t|XmlQuux|]
 
-"Root" =:= record Both
+"Root" =:= record Both LensRename
   ! "{http://example.com/ns/my-namespace}Foo"
 
 instance Arbitrary XmlRoot where

--- a/test/TestDefs.hs
+++ b/test/TestDefs.hs
@@ -23,13 +23,13 @@ import Test.QuickCheck.Instances ()
   & "US"
 
 "Foo" =:= record Both NoLens
-  ^ "Shmuux" [t|XmlQuux|]
-  + "Bar"
-  ? "Baz" [t|Text|]
-  !% "Quux"
-  ?% "Muux" [t|XmlQuux|]
+  ^ "shmuux" [t|XmlQuux|]
+  + "bar"
+  ? "baz" [t|Text|]
+  !% "quux"
+  ?% "muux" [t|XmlQuux|]
 
-"Root" =:= record Both LensRename
+"Root" =:= record Both LensRenaming
   ! "{http://example.com/ns/my-namespace}Foo"
 
 instance Arbitrary XmlRoot where


### PR DESCRIPTION
I want to make it possible to generate code with https://github.com/dredozubov/xsd-isogen to use `DuplicateRecordFields` and `generic-lens` rather than old-fashion prefixes lenses as implemented in `xml-isogen`, so I make it opt-in to support both old and new styles. We need to pass additional argument to `record`(`Lens` or `NoLens`) to select the style.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/typeable/xml-isogen/19)
<!-- Reviewable:end -->
