### PR TITLE
Rename Both to ParserAndGenerator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ dist
 .stack-work
 .cabal-sandbox/
 cabal.sandbox.config
+
+# vim backup and swap files
+*~
+.*.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 HEAD
 ------
 
-* Rename Both to ParserAndGenerator
+* Rename Both to ParserAndGenerator (#27)
 * Add Nillable newtype (#24)
 * Include digits in the auto-gerenated prefix (#22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 HEAD
 ------
 
+* Rename Both to ParserAndGenerator
+* Add Nillable newtype (#24)
+* Include digits in the auto-gerenated prefix (#22)
+
 0.3.0
 ------
 

--- a/src/Data/THGen/XML.hs
+++ b/src/Data/THGen/XML.hs
@@ -22,7 +22,7 @@ wrapper around the field type:
 
 Example 1.
 
-> "Color" =:= enum Both
+> "Color" =:= enum ParserAndGenerator
 >   & "R"
 >   & "G"
 >   & "B"
@@ -40,7 +40,7 @@ to be either @R@, @G@ or @B@.
 
 Example 2.
 
-> "Message" =:= record Both
+> "Message" =:= record ParserAndGenerator
 >   ! "author"
 >   + "recipient"
 >   ? "message" [t|Text|]
@@ -93,7 +93,7 @@ The type of the field is inferred automatically from its name, so
 if the field is called @"author"@ its type will be @Author@. You can
 override the type by specifying it in quasiquotes like so:
 
-> "Message" =:= record Both
+> "Message" =:= record ParserAndGenerator
 >   ! "author" [t|Person|].
 >   ...
 

--- a/src/Data/THGen/XML/Internal.hs
+++ b/src/Data/THGen/XML/Internal.hs
@@ -24,7 +24,7 @@ import           Text.XML.ParentAttributes
 import qualified Text.XML.Writer as XW
 
 
-data GenType = Parser | Generator | Both
+data GenType = Parser | Generator | ParserAndGenerator
 
 data XmlFieldPlural
   = XmlFieldPluralMandatory  -- Occurs exactly 1 time (Identity)
@@ -230,7 +230,7 @@ isoXmlGenerateEnum genType (ExhaustivenessName strName' exh) enumCons = do
       fromDomInst <- genFromDomInst
       fromAttributeInst <- genFromAttributeInst
       return $ enumDecls ++ [fromDomInst, fromAttributeInst]
-    Both -> do
+    ParserAndGenerator -> do
       toXmlInst <- genToXmlInst
       toXmlAttributeInst <- genToXmlAttributeInst
       fromDomInst <- genFromDomInst
@@ -398,7 +398,7 @@ isoXmlGenerateDatatype genType (PrefixName strName' strPrefix') descRecordParts 
     Parser -> do
       fromDomInst <- genFromDomInst
       return $ [termDecl] ++ lensDecls ++ [fromDomInst, nfDataInst]
-    Both -> do
+    ParserAndGenerator -> do
       toXmlInst <- genToXmlInst
       toXmlParentAttributesInst <- genToXmlParentAttributeInst
       fromDomInst <- genFromDomInst

--- a/test/TestDefs.hs
+++ b/test/TestDefs.hs
@@ -9,11 +9,11 @@ import Data.THGen.XML
 import Test.QuickCheck.Arbitrary.Generic
 import Test.QuickCheck.Instances ()
 
-"Bar" =:= enum Both
+"Bar" =:= enum ParserAndGenerator
   & "baroque"
   & "bartender"
 
-"Quux" Exhaustive =:= enum Both
+"Quux" Exhaustive =:= enum ParserAndGenerator
   & "ALL"
   & "YOUR"
   & "BASE"
@@ -22,14 +22,14 @@ import Test.QuickCheck.Instances ()
   & "TO"
   & "US"
 
-"Foo" =:= record Both
+"Foo" =:= record ParserAndGenerator
   ^ "Shmuux" [t|XmlQuux|]
   + "Bar"
   ? "Baz" [t|Text|]
   !% "Quux"
   ?% "Muux" [t|XmlQuux|]
 
-"Root" =:= record Both
+"Root" =:= record ParserAndGenerator
   ! "{http://example.com/ns/my-namespace}Foo"
 
 instance Arbitrary XmlRoot where


### PR DESCRIPTION
Closes #20 

- Rename `Both` to `ParserAndGenerator`
- Update the change log
- add vim related files to `.gitignore`